### PR TITLE
Require Input for Lock On when Scanning Signals

### DIFF
--- a/contact.gd
+++ b/contact.gd
@@ -1,16 +1,7 @@
 extends RigidBody2D
 
-signal locked
-
-var contact_to_remove
-
 func _ready() -> void:
 	add_to_group("contacts")
 
 func _process(_delta: float) -> void:
 	pass
-
-func _lock_contact_by_id (contact_id):
-	print("Removing contact " + str(contact_id))
-	contact_to_remove = instance_from_id(contact_id)
-	contact_to_remove.queue_free()

--- a/contact.gd
+++ b/contact.gd
@@ -2,8 +2,15 @@ extends RigidBody2D
 
 signal locked
 
+var contact_to_remove
+
 func _ready() -> void:
 	add_to_group("contacts")
 
 func _process(_delta: float) -> void:
 	pass
+
+func _lock_contact_by_id (contact_id):
+	print("Removing contact " + str(contact_id))
+	contact_to_remove = instance_from_id(contact_id)
+	contact_to_remove.queue_free()

--- a/contact.tscn
+++ b/contact.tscn
@@ -26,5 +26,3 @@ sprite_frames = SubResource("SpriteFrames_8dwoj")
 
 [node name="CollisionShape2D2" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_kfmgx")
-
-[connection signal="locked" from="." to="." method="_lock_contact_by_id"]

--- a/contact.tscn
+++ b/contact.tscn
@@ -26,7 +26,3 @@ sprite_frames = SubResource("SpriteFrames_8dwoj")
 
 [node name="CollisionShape2D2" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_kfmgx")
-
-[connection signal="body_entered" from="." to="." method="_on_body_entered"]
-[connection signal="body_shape_entered" from="." to="." method="_on_body_shape_entered"]
-[connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]

--- a/contact.tscn
+++ b/contact.tscn
@@ -26,3 +26,5 @@ sprite_frames = SubResource("SpriteFrames_8dwoj")
 
 [node name="CollisionShape2D2" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_kfmgx")
+
+[connection signal="locked" from="." to="." method="_lock_contact_by_id"]

--- a/cursor.gd
+++ b/cursor.gd
@@ -38,19 +38,16 @@ func _on_body_entered(body):
 	# Ideally this should activate an animation on the signal, but this'll do for now
 	$contact_isolated.play()
 	on_contact = body
+	
+	# Send a connected call to the server indicating it's been isolated
 		
 func lock_contact(body):	
 	if body.is_in_group("contacts"):
 		on_contact = null
 		locked.emit(body.get_instance_id())
-		#print(body)
-		#print("Sending lock signal for " + str(body.get_instance_id()))
-		lock_contact_by_id(body.get_instance_id())
 		
 func lock_contact_by_id (contact_id):
-	print("Removing contact " + str(contact_id))
 	var contact_to_remove = instance_from_id(int(contact_id))
-	print(contact_to_remove)
 	contact_to_remove.queue_free()
 	
 func start(pos):

--- a/cursor.gd
+++ b/cursor.gd
@@ -39,16 +39,12 @@ func _on_body_entered(body):
 	$contact_isolated.play()
 	on_contact = body
 		
-func lock_contact(body):
-	
-	# For some reason some instances don't have a contact name
-	#if body.name == "contact":
-	#print(body.name)
-	
+func lock_contact(body):	
 	if body.is_in_group("contacts"):
-		body.queue_free()
+		#body.queue_free()
 		on_contact = null
-		locked.emit()
+		locked.emit(body.get_instance_id())
+		print("Sending lock signal for " + str(body.get_instance_id()))
 	
 func start(pos):
 	position = pos

--- a/cursor.gd
+++ b/cursor.gd
@@ -45,7 +45,7 @@ func lock_contact(body):
 	#if body.name == "contact":
 	#print(body.name)
 	
-	if body is RigidBody2D:
+	if body.is_in_group("contacts"):
 		body.queue_free()
 		on_contact = null
 		locked.emit()

--- a/cursor.gd
+++ b/cursor.gd
@@ -44,11 +44,16 @@ func _on_body_entered(body):
 func lock_contact(body):	
 	if body.is_in_group("contacts"):
 		on_contact = null
+		remove_body(body)
 		locked.emit(body.get_instance_id())
 		
 func lock_contact_by_id (contact_id):
 	var contact_to_remove = instance_from_id(int(contact_id))
-	contact_to_remove.queue_free()
+	remove_body(contact_to_remove)
+	locked.emit(int(contact_id))
+	
+func remove_body (body):
+	body.queue_free()
 	
 func start(pos):
 	position = pos

--- a/cursor.gd
+++ b/cursor.gd
@@ -41,10 +41,17 @@ func _on_body_entered(body):
 		
 func lock_contact(body):	
 	if body.is_in_group("contacts"):
-		#body.queue_free()
 		on_contact = null
 		locked.emit(body.get_instance_id())
-		print("Sending lock signal for " + str(body.get_instance_id()))
+		#print(body)
+		#print("Sending lock signal for " + str(body.get_instance_id()))
+		lock_contact_by_id(body.get_instance_id())
+		
+func lock_contact_by_id (contact_id):
+	print("Removing contact " + str(contact_id))
+	var contact_to_remove = instance_from_id(int(contact_id))
+	print(contact_to_remove)
+	contact_to_remove.queue_free()
 	
 func start(pos):
 	position = pos

--- a/cursor.gd
+++ b/cursor.gd
@@ -28,7 +28,7 @@ func _process(delta) -> void:
 
 	position += velocity * delta
 	position = position.clamp(Vector2.ZERO, screen_size)
-	
+		
 	if Input.is_action_pressed("space"):
 		if on_contact != null:
 			lock_contact(on_contact)

--- a/cursor.gd
+++ b/cursor.gd
@@ -2,8 +2,10 @@ extends Area2D
 
 @export var speed = 400
 var screen_size
+var on_contact
 
 signal hit
+signal locked
 
 func _ready() -> void:
 	hide()
@@ -26,17 +28,27 @@ func _process(delta) -> void:
 
 	position += velocity * delta
 	position = position.clamp(Vector2.ZERO, screen_size)
+	
+	if Input.is_action_pressed("space"):
+		if on_contact != null:
+			lock_contact(on_contact)
 
 func _on_body_entered(body):
 	hit.emit()
+	# Ideally this should activate an animation on the signal, but this'll do for now
+	$contact_isolated.play()
+	on_contact = body
+		
+func lock_contact(body):
 	
 	# For some reason some instances don't have a contact name
-	print(body.name)
-	
 	#if body.name == "contact":
+	#print(body.name)
+	
 	if body is RigidBody2D:
 		body.queue_free()
-		#print("hit!")
+		on_contact = null
+		locked.emit()
 	
 func start(pos):
 	position = pos

--- a/cursor.tscn
+++ b/cursor.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=5 format=3 uid="uid://bx033pw32ucqt"]
+[gd_scene load_steps=6 format=3 uid="uid://bx033pw32ucqt"]
 
 [ext_resource type="Script" path="res://cursor.gd" id="1_jpcwt"]
 [ext_resource type="Texture2D" uid="uid://bc32wskprvpmb" path="res://assets/contact_cursor.png" id="1_qcy51"]
+[ext_resource type="AudioStream" uid="uid://bbgwv7mtpoqit" path="res://assets/sounds/impactMetal_003.ogg" id="3_g8vgh"]
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_ef7h1"]
 animations = [{
@@ -15,7 +16,7 @@ animations = [{
 }]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_5xncm"]
-radius = 64.0078
+radius = 46.0435
 
 [node name="cursor" type="Area2D"]
 script = ExtResource("1_jpcwt")
@@ -26,5 +27,8 @@ sprite_frames = SubResource("SpriteFrames_ef7h1")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_5xncm")
+
+[node name="contact_isolated" type="AudioStreamPlayer2D" parent="."]
+stream = ExtResource("3_g8vgh")
 
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/main.gd
+++ b/main.gd
@@ -77,8 +77,8 @@ func server_heartbeat_timeout():
 func contact_server(id, session, status, message, event_type):
 
 	contact_id = str(id)
-	status = status.uri_encode()
 	session = str(session)
+	status = status.uri_encode()
 	message = message.uri_encode()
 
 #	# This one gets mad about initializing
@@ -100,13 +100,17 @@ func contact_server(id, session, status, message, event_type):
 func _on_request_completed(result, response_code, headers, body):
 	var json = JSON.parse_string(body.get_string_from_utf8())
 	#print(response_code, headers)
-	print(json)
+	#print(json)
 	update_game(json)
 	
 func update_game(heartbeat):
 	if 'status' in heartbeat && heartbeat.status == "locked":
 		print("Sending lock signal for " + str(heartbeat.id))
-		locked.emit(heartbeat.id)
+		for contact in contact.get_children():
+			if heartbeat.id == contact.id:
+					print("Should remove: " + contact.id)
+		#locked.emit(heartbeat.id)
+		#$cursor.lock_contact_by_id(heartbeat.id)
 	
 # Game start/end methods
 func new_game():

--- a/main.gd
+++ b/main.gd
@@ -1,11 +1,14 @@
 extends Node
 
 @export var contact: PackedScene
+@export var ship_speed = 10
+@export var signal_rate = 5000
+@export var max_contacts = 5
+
 var score = 0
 var search_for_life = 0
 var total_contacts = 0
 var at_menu = 1
-var ship_speed = 10
 
 signal gameover
 
@@ -21,8 +24,8 @@ func _process(_delta) -> void:
 		if ship_speed > 5:
 			ship_speed -= 5
 	
-	if total_contacts < 50 and at_menu == 0:
-		search_for_life = randi_range(0,50000) / ship_speed
+	if total_contacts < max_contacts and at_menu == 0:
+		search_for_life = randi_range(1,signal_rate) / ship_speed
 		print(search_for_life)
 		if search_for_life < 5:
 			var contact = contact.instantiate()

--- a/main.gd
+++ b/main.gd
@@ -55,8 +55,7 @@ func _process(_delta) -> void:
 			var contact = contact.instantiate()
 			contact.position = Vector2(randi_range(200,1100), randi_range(100,550))
 			add_child(contact)
-			contact_id = contact.get_instance_id()
-			contact_server(contact_id, 1337, "detected", "A new contact has appeared", "update")
+			contact_server(contact.get_instance_id(), 1337, "detected", "A new contact has appeared", "update")
 			$contact_new.play()
 			total_contacts = total_contacts + 1
 
@@ -67,7 +66,10 @@ func _increment_signals(contact_id):
 	$HUD.update_score(score)
 	#print("Remove contact with id: " + str(contact_id))
 	contact_server(contact_id, 1337, "locked", "Contact locked", "update")
+	#print(score)
 	if score > 3:
+		#on_gameover()
+		# For some reason the signal suddenly isn't working anymore
 		gameover.emit()
 		get_tree().call_group("contacts", "queue_free")
 
@@ -93,22 +95,24 @@ func contact_server(id, session, status, message, event_type):
 	var send_request = request.request(
 		url, headers, HTTPClient.METHOD_GET)
 		
-	if send_request != OK:
+	#if send_request != OK:
 		#print(url)
-		print('Issue with request')
+		#print('Issue with request')
 	
 func _on_request_completed(result, response_code, headers, body):
 	var json = JSON.parse_string(body.get_string_from_utf8())
 	#print(response_code, headers)
-	#print(json)
+	print(json)
 	update_game(json)
 	
 func update_game(heartbeat):
 	if 'status' in heartbeat && heartbeat.status == "locked":
-		print("Sending lock signal for " + str(heartbeat.id))
-		for contact in contact.get_children():
-			if heartbeat.id == contact.id:
-					print("Should remove: " + contact.id)
+		#print("Sending lock signal for " + str(heartbeat.id))
+		if instance_from_id(int(heartbeat.id)):
+			print("Should remove: " + heartbeat.id)
+		#for contact in contact.get_wchildren():
+			#if heartbeat.id == contact.id:
+					#print("Should remove: " + contact.id)
 		#locked.emit(heartbeat.id)
 		#$cursor.lock_contact_by_id(heartbeat.id)
 	

--- a/main.gd
+++ b/main.gd
@@ -17,7 +17,7 @@ func _process(_delta) -> void:
 		search_for_life = randi_range(0,5000)
 		if search_for_life < 50:
 			var contact = contact.instantiate()
-			contact.position = Vector2(randi_range(100,1100), randi_range(100,550))
+			contact.position = Vector2(randi_range(200,1100), randi_range(100,550))
 			add_child(contact)
 			$contact_new.play()
 			total_contacts = total_contacts + 1

--- a/main.gd
+++ b/main.gd
@@ -5,6 +5,7 @@ var score = 0
 var search_for_life = 0
 var total_contacts = 0
 var at_menu = 1
+var ship_speed = 10
 
 signal gameover
 
@@ -12,10 +13,18 @@ func _ready() -> void:
 	pass
 
 func _process(_delta) -> void:
+
+	if Input.is_action_pressed("speed_up"):
+		if ship_speed < 200:
+			ship_speed += 10
+	if Input.is_action_pressed("speed_down"):
+		if ship_speed > 5:
+			ship_speed -= 5
 	
-	if total_contacts < 3 and at_menu == 0:
-		search_for_life = randi_range(0,5000)
-		if search_for_life < 50:
+	if total_contacts < 50 and at_menu == 0:
+		search_for_life = randi_range(0,50000) / ship_speed
+		print(search_for_life)
+		if search_for_life < 5:
 			var contact = contact.instantiate()
 			contact.position = Vector2(randi_range(200,1100), randi_range(100,550))
 			add_child(contact)

--- a/main.gd
+++ b/main.gd
@@ -30,8 +30,6 @@ func _increment_signals():
 	if score > 3:
 		gameover.emit()
 		get_tree().call_group("contacts", "queue_free")
-		#for contact in get_tree().get_nodes_in_group("contacts"):
-			#contact.queue_free()
 
 func new_game():
 	score = 0

--- a/main.gd
+++ b/main.gd
@@ -5,15 +5,40 @@ extends Node
 @export var signal_rate = 5000
 @export var max_contacts = 5
 
+var request : HTTPRequest
+var root_url : String = "https://typeri.us/dora_brain?"
+
 var score = 0
 var search_for_life = 0
 var total_contacts = 0
 var at_menu = 1
 
+var headers
+var body
+var contact_id
+var session
+var status
+var message
+var source = "game_client"
+
+# Set up the server sync
+@export_range(0, 1, 0.05, "suffix:s", "or_greater")
+var heartbeat_delay: float = 3.0
+var server_heartbeat := Timer.new()
+
 signal gameover
+signal locked
 
 func _ready() -> void:
-	pass
+	request = HTTPRequest.new()
+	add_child(request)
+	request.connect("request_completed", _on_request_completed)
+
+	add_child(server_heartbeat)
+	server_heartbeat.wait_time = heartbeat_delay
+	server_heartbeat.one_shot = false
+	server_heartbeat.connect("timeout", server_heartbeat_timeout)
+	server_heartbeat.start()
 
 func _process(_delta) -> void:
 
@@ -26,30 +51,74 @@ func _process(_delta) -> void:
 	
 	if total_contacts < max_contacts and at_menu == 0:
 		search_for_life = randi_range(1,signal_rate) / ship_speed
-		print(search_for_life)
 		if search_for_life < 5:
 			var contact = contact.instantiate()
 			contact.position = Vector2(randi_range(200,1100), randi_range(100,550))
 			add_child(contact)
+			contact_id = contact.get_instance_id()
+			contact_server(contact_id, 1337, "detected", "A new contact has appeared", "update")
 			$contact_new.play()
 			total_contacts = total_contacts + 1
 
-func _increment_signals():
+func _increment_signals(contact_id):
 	$contact_locked.play()
 	score = score + 1
 	total_contacts = total_contacts - 1
 	$HUD.update_score(score)
+	#print("Remove contact with id: " + str(contact_id))
+	contact_server(contact_id, 1337, "locked", "Contact locked", "update")
 	if score > 3:
 		gameover.emit()
 		get_tree().call_group("contacts", "queue_free")
 
+func server_heartbeat_timeout():
+	var heartbeat = contact_server(1, 1337, "none", "none", "sync")
+	
+func contact_server(id, session, status, message, event_type):
+
+	contact_id = str(id)
+	status = status.uri_encode()
+	session = str(session)
+	message = message.uri_encode()
+
+#	# This one gets mad about initializing
+	#var params = request.HTTPClient.query_string_from_dict(fields)
+	
+	headers = ["Content-type: application/json"]
+	var url = root_url
+	var params = ""
+	params = "id="+contact_id+"&session="+session+"&event_type="+event_type+"&status="+status+"&source="+source+"&message="+message
+	
+	url = url + params
+	var send_request = request.request(
+		url, headers, HTTPClient.METHOD_GET)
+		
+	if send_request != OK:
+		#print(url)
+		print('Issue with request')
+	
+func _on_request_completed(result, response_code, headers, body):
+	var json = JSON.parse_string(body.get_string_from_utf8())
+	#print(response_code, headers)
+	print(json)
+	update_game(json)
+	
+func update_game(heartbeat):
+	if 'status' in heartbeat && heartbeat.status == "locked":
+		print("Sending lock signal for " + str(heartbeat.id))
+		locked.emit(heartbeat.id)
+	
+# Game start/end methods
 func new_game():
 	score = 0
 	at_menu = 0
+	contact_server(1, 1337, "none", "Scanner warming up", "update")
 	$cursor.start($StartPosition.position)
 
 func _on_gameover():
 	score = 0
 	total_contacts = 0 
 	at_menu = 1
-	await get_tree().create_timer(1.0).timeout
+	await get_tree().create_timer(2.0).timeout
+	contact_server(1, 1337, "none", "No contacts present", "update")
+	

--- a/main.gd
+++ b/main.gd
@@ -102,20 +102,16 @@ func contact_server(id, session, status, message, event_type):
 func _on_request_completed(result, response_code, headers, body):
 	var json = JSON.parse_string(body.get_string_from_utf8())
 	#print(response_code, headers)
-	print(json)
+	#print(json)
 	update_game(json)
 	
 func update_game(heartbeat):
 	if 'status' in heartbeat && heartbeat.status == "locked":
-		#print("Sending lock signal for " + str(heartbeat.id))
 		if instance_from_id(int(heartbeat.id)):
-			print("Should remove: " + heartbeat.id)
-		#for contact in contact.get_wchildren():
-			#if heartbeat.id == contact.id:
-					#print("Should remove: " + contact.id)
-		#locked.emit(heartbeat.id)
-		#$cursor.lock_contact_by_id(heartbeat.id)
-	
+			$cursor.lock_contact_by_id(heartbeat.id)
+			_increment_signals(heartbeat.id)
+
+
 # Game start/end methods
 func new_game():
 	score = 0

--- a/main.tscn
+++ b/main.tscn
@@ -17,7 +17,7 @@ contact = ExtResource("2_j4duc")
 wait_time = 3.0
 
 [node name="StartPosition" type="Marker2D" parent="."]
-position = Vector2(240, 450)
+position = Vector2(150, 200)
 
 [node name="HUD" parent="." instance=ExtResource("4_33h0t")]
 
@@ -30,5 +30,5 @@ stream = ExtResource("6_u0sbw")
 [connection signal="gameover" from="." to="." method="_on_gameover"]
 [connection signal="gameover" from="." to="cursor" method="_on_main_gameover"]
 [connection signal="gameover" from="." to="HUD" method="_on_main_gameover"]
-[connection signal="hit" from="cursor" to="." method="_increment_signals"]
+[connection signal="locked" from="cursor" to="." method="_increment_signals"]
 [connection signal="start_game" from="HUD" to="." method="new_game"]

--- a/main.tscn
+++ b/main.tscn
@@ -28,5 +28,8 @@ stream = ExtResource("5_fc2di")
 [node name="contact_locked" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource("6_u0sbw")
 
+[connection signal="gameover" from="." to="." method="_on_gameover"]
+[connection signal="gameover" from="." to="cursor" method="_on_main_gameover"]
+[connection signal="gameover" from="." to="HUD" method="_on_main_gameover"]
 [connection signal="locked" from="cursor" to="." method="_increment_signals"]
 [connection signal="start_game" from="HUD" to="." method="new_game"]

--- a/main.tscn
+++ b/main.tscn
@@ -10,6 +10,7 @@
 [node name="main" type="Node"]
 script = ExtResource("1_fl0d2")
 contact = ExtResource("2_j4duc")
+max_contacts = 3
 
 [node name="cursor" parent="." instance=ExtResource("1_q57yj")]
 
@@ -27,8 +28,5 @@ stream = ExtResource("5_fc2di")
 [node name="contact_locked" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource("6_u0sbw")
 
-[connection signal="gameover" from="." to="." method="_on_gameover"]
-[connection signal="gameover" from="." to="cursor" method="_on_main_gameover"]
-[connection signal="gameover" from="." to="HUD" method="_on_main_gameover"]
 [connection signal="locked" from="cursor" to="." method="_increment_signals"]
 [connection signal="start_game" from="HUD" to="." method="new_game"]

--- a/project.godot
+++ b/project.godot
@@ -42,6 +42,16 @@ space={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
 ]
 }
+speed_up={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"location":0,"echo":false,"script":null)
+]
+}
+speed_down={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":81,"key_label":0,"unicode":113,"location":0,"echo":false,"script":null)
+]
+}
 
 [rendering]
 


### PR DESCRIPTION
This change will add a step between hovering over the signal and counting it as locked.

Hovering should not increment score nor remove the signal, instead should allow the player the _option_ to lock the signal so that when additional information is available, they can choose whether to attempt to lock it or not.